### PR TITLE
Add the ability to export elements with multiple texts

### DIFF
--- a/helpers/CsvExportFunctions.php
+++ b/helpers/CsvExportFunctions.php
@@ -33,17 +33,13 @@ function getCsvRow($item, $elements) {
     // Element texts
     $elementTexts = get_db()->getTable('ElementText')->findByRecord($item);
     foreach ($elements as $element) {
-        $hasEmptyElementText = true;
+        $accumulatedTexts = array();
         foreach ($elementTexts as $elementText) {
             if ($elementText->element_id === $element->id) {
-                $row[] = $elementText->text;
-                $hasEmptyElementText = false;
-                break;
+                $accumulatedTexts[] = $elementText->text;
             }
         }
-        if ($hasEmptyElementText) {
-            $row[] = '';
-        }
+        $row[] = join('^^', $accumulatedTexts);
     }
     // Tail with tags, file, itemType, collection, public, featured
     // Tags


### PR DESCRIPTION
This PR is a response to #11. Apparently the magic separator in Omeka.net's CSV format is ```^^```.